### PR TITLE
Fixed the molecule function to set the owner properly on init calls

### DIFF
--- a/templates/dotfiles/bashrc.j2
+++ b/templates/dotfiles/bashrc.j2
@@ -77,7 +77,12 @@ if type -p go > /dev/null; then
 fi
 
 function molecule(){
-    docker run --rm -it -v $(pwd):/tmp/$(basename "${PWD}") -v /var/run/docker.sock:/var/run/docker.sock -w /tmp/$(basename "${PWD}") {{ molecule_image }}  sudo molecule "$@" 
+    docker pull {{ molecule_image }} > /dev/null 2>&1
+    if [ $1 = 'init' ]; then
+      docker run --rm -it -e HOME=/tmp --user $(id -u):$(id -g) -v $(pwd):/tmp/$(basename "${PWD}") -v /var/run/docker.sock:/var/run/docker.sock -w /tmp/$(basename "${PWD}") {{ molecule_image }}  sudo molecule "$@" 
+    else
+      docker run --rm -it -v $(pwd):/tmp/$(basename "${PWD}") -v /var/run/docker.sock:/var/run/docker.sock -w /tmp/$(basename "${PWD}") {{ molecule_image }}  sudo molecule "$@" 
+    fi
 }
 
 # Location specific aliases and functions


### PR DESCRIPTION
Because the molecule container runs as root, whenever a molecule init is run the directory created is owned by root, which is kind of a pain. This PR checks to see if $1 is init, and if so runs molecule a little differently so that the owner is fixed.

The other change is that the function now pulls the image from the docker registry every time, so that you always have the latest version of the container.